### PR TITLE
Parses layout_geometry from URL and DOM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .DS_Store
 .idea
 **/.turbo
+**/mise.toml
 
 # compiled
 chrome-extension/public/manifest.json
@@ -26,3 +27,4 @@ chrome-extension/public/manifest.json
 dist.pem
 dist.crx
 dist.zip
+

--- a/packages/shared/lib/utils/parse.ts
+++ b/packages/shared/lib/utils/parse.ts
@@ -1,7 +1,120 @@
-export const parseOryxUrl = () => {
+enum Keyboard {
+  ergodox_ez = 'ergodox_ez',
+  ergodox_ez_st = 'ergodox_ez_st',
+  planck_ez = 'planck_ez',
+  moonlander = 'moonlander',
+  voyager = 'voyager',
+  unknown = 'unknown',
+}
+
+enum Chipset {
+  stm = 'stm',
+  stm32 = 'stm32',
+  m32u4 = 'm32u4',
+  unspecified = 'unspecified',
+}
+
+enum Model {
+  original = 'original',
+  glow = 'glow',
+  shine = 'shine',
+  unspecified = 'unspecified',
+}
+
+export class QmkLayout {
+  id: string;
+  keyboard: Keyboard = Keyboard.unknown;
+  chipset: Chipset = Chipset.unspecified;
+  model: Model;
+
+  constructor(_id: string, _keyboard: Keyboard, _chipset: Chipset, _model: Model) {
+    this.id = _id;
+    if (Keyboard[_keyboard]) {
+      let { keyboard, chipset } = QmkLayout._ergodoxish(_keyboard)
+        ? QmkLayout._ergodoxAndChipset(_keyboard)
+        : {
+            keyboard: Keyboard[_keyboard] ?? Keyboard.unknown,
+            chipset: Chipset[_chipset] ?? Chipset.unspecified,
+          };
+      if (keyboard === Keyboard[Keyboard.unknown]) {
+        throw new RangeError(`Keyboard '${keyboard}' is unknown. \
+          If ZSA has come out with a new type of keyboard, file an support request \
+          at https://github.com/nivekmai/oryx-build-extension/issues.`);
+      }
+      this.keyboard = keyboard;
+      this.chipset = chipset;
+    }
+    this.model = Model[_model] ? (_model as Model) : Model.unspecified;
+  }
+
+  static from(id: string, keyboard: string, chipset: string | undefined, model: string): QmkLayout {
+    return new QmkLayout(
+      id,
+      keyboard ? (QmkLayout.sanitizeInput(keyboard) as Keyboard) : Keyboard.unknown,
+      chipset ? (QmkLayout.sanitizeInput(chipset) as Chipset) : Chipset.unspecified,
+      model ? (QmkLayout.sanitizeInput(model) as Model) : Model.unspecified,
+    );
+  }
+
+  static bootstrap(): QmkLayout {
+    const { layout_geometry, layout_id } = parseOryxUrl();
+    const model = QmkLayout._queryDomForModel();
+    return QmkLayout.from(layout_id, layout_geometry ?? Keyboard.unknown, Chipset.unspecified, model);
+  }
+
+  static sanitizeInput(s: string): string {
+    return s
+      .replace(/[^A-z0-9]/g, '_')
+      .trim()
+      .toLowerCase();
+  }
+
+  static _ergodoxish(kbd: Keyboard | string | undefined): boolean {
+    return kbd ? (QmkLayout.sanitizeInput(kbd as string)?.startsWith('ergodox') ?? false) : false;
+  }
+
+  static _ergodoxAndChipset(kbd: Keyboard): { keyboard: Keyboard; chipset: Chipset } {
+    let chipset: Chipset, keyboard: Keyboard;
+    if (Keyboard[kbd] === Keyboard[Keyboard.ergodox_ez_st]) {
+      chipset = Chipset.stm32;
+    } else {
+      chipset = Chipset.m32u4;
+    }
+    keyboard = Keyboard.ergodox_ez;
+    return { keyboard, chipset };
+  }
+
+  static _queryDomForModel(): string {
+    const tags = 'h1 ~ div > .tag.default';
+    const active_model = '.model-toggle .entry > .active';
+    const firstMatch = document.querySelector(`${tags}, ${active_model}`)?.textContent;
+    if (firstMatch) {
+      return QmkLayout.sanitizeInput(firstMatch);
+    }
+    return Model.unspecified;
+  }
+
+  update(layout: QmkLayout | undefined): void {
+    const updated = layout ?? QmkLayout.bootstrap();
+    this.id = updated.id;
+    this.keyboard = updated.keyboard;
+    this.chipset = updated.chipset;
+    this.model = updated.model;
+  }
+
+  get geometry() {
+    const blacklisted = [Model.original, Model.unspecified, Chipset.unspecified, Keyboard.unknown];
+    return [this.keyboard, this.chipset, this.model]
+      .filter(v => !blacklisted.includes(v))
+      .map(v => v.toString())
+      .reduce((l, r) => l + '/' + r);
+  }
+}
+
+const parseOryxUrl = () => {
   const [, raw_layout_geometry, layout_id] =
     window.location.href.match('https://configure.zsa.io/([^/]+)/layouts/([^/]+)') || [];
-  const layout_geometry = raw_layout_geometry.replace('-', '_');
+  const layout_geometry = QmkLayout.sanitizeInput(raw_layout_geometry);
   return { layout_geometry, layout_id };
 };
 

--- a/pages/content-ui/src/App.tsx
+++ b/pages/content-ui/src/App.tsx
@@ -177,7 +177,6 @@ export default function App() {
   };
 
   if (!qmk_layout.id) {
-    console.warn(`layout_geometry: ${layout_geometry}, qmk_layout: ${JSON.stringify(qmk_layout)}`);
     // not on a layout page
     return null;
   }

--- a/pages/options/src/Options.tsx
+++ b/pages/options/src/Options.tsx
@@ -57,10 +57,11 @@ const Options = () => {
       />
       <hr />
       <div className="py-1 text-left text-sm text-white">
-        If your layout_geometry is not available from the Oryx URL (e.g. moonlander, voyager, plank_ez, or ergodox_ez),
-        you can use this to override the layout_geometry in the workflow.
+        If your layout_geometry is not fully specified in from the Oryx URL (e.g. <i>plank_ez/glow</i>, or{' '}
+        <i>ergodox_ez/stm32/shine</i>), you can use this to override the layout_geometry in the workflow. This is NOT
+        recommended for users with more than 1 type of ZSA keyboard.
         <br />
-        Leave blank to use the URL.
+        Leave blank to let the extension figure this out each time you kick off a workflow.
       </div>
       <Input
         label="Layout Geometry Override"


### PR DESCRIPTION
The class `QmkLayout` and some supporting enums for `Keyboard`, `Chipset`, and `Model` map to the namespacing in [ZSA's fork of QMK][qmk.zsa.kbds] that is used by [forks of `poulainpi/oryx-with-custom-qmk`][oryx++forks].

[oryx++forks]: https://github.com/poulainpi/oryx-with-custom-qmk/forks
[qmk.zsa.kbds]: https://github.com/zsa/qmk_firmware/tree/firmware24/keyboards/zsa

The 'Layout Geometry Override' (see #1) is still respected as the first trusted value. As noted in [Options.tsx][tsx], this can get a little sticky if you are working with many types of ZSA keyboards in Oryx.

[tsx]: pages/options/src/Options.tsx

Sample builds, driven by the extension:

layout geometry       | oryx                        | github actions
----------------------|-----------------------------|----------------------------
ergodox_ez/stm32      | [VRy94][oryx.ergodox.shine] | [x 6][blehrer.actions.6]
ergodox_ez/stm32/shine| [VRy94][oryx.ergodox.shine] | [✓ 8][blehrer.actions.8]
ergodox_ez/stm32      | [ndVrG][oryx.ergodox]       | [✓ 9][blehrer.actions.9]
voyager               | [5pGRB][oryx.voyager]       | [✓ 11][blehrer.actions.11]

[oryx.ergodox.shine]: https://configure.zsa.io/ergodox-ez-st/layouts/VRy94/latest/0
[oryx.ergodox]: https://configure.zsa.io/ergodox-ez-st/layouts/ndVrG/latest/0
[oryx.voyager]: https://configure.zsa.io/voyager/layouts/5pGRB/latest/0

[blehrer.actions.8]: https://github.com/blehrer/oryx-with-custom-qmk/actions/runs/13149236291
[blehrer.actions.9]: https://github.com/blehrer/oryx-with-custom-qmk/actions/runs/13149268119
[blehrer.actions.11]: https://github.com/blehrer/oryx-with-custom-qmk/actions/runs/13149362022
[blehrer.actions.6]: https://github.com/blehrer/oryx-with-custom-qmk/actions/runs/13148297674