### PR TITLE
refactor(parse.ts): fix lint check

### DIFF
--- a/packages/shared/lib/utils/parse.ts
+++ b/packages/shared/lib/utils/parse.ts
@@ -31,7 +31,7 @@ export class QmkLayout {
   constructor(_id: string, _keyboard: Keyboard, _chipset: Chipset, _model: Model, _error?: Error) {
     this.id = _id;
     if (Keyboard[_keyboard]) {
-      let { keyboard, chipset } = QmkLayout._ergodoxish(_keyboard)
+      const { keyboard, chipset } = QmkLayout._ergodoxish(_keyboard)
         ? QmkLayout._ergodoxAndChipset(_keyboard)
         : {
             keyboard: Keyboard[_keyboard] ?? Keyboard.unknown,
@@ -41,7 +41,7 @@ export class QmkLayout {
       this.keyboard = keyboard;
       this.chipset = chipset;
     }
-    this.model = Model[_model] ? (_model as Model) : Model.unspecified;
+    this.model = Model[_model] ?? Model.unspecified;
   }
 
   static from(id: string, keyboard: string, chipset?: string, model?: string): QmkLayout {
@@ -81,14 +81,8 @@ export class QmkLayout {
   }
 
   static _ergodoxAndChipset(kbd: Keyboard): { keyboard: Keyboard; chipset: Chipset } {
-    let chipset: Chipset, keyboard: Keyboard;
-    if (Keyboard[kbd] === Keyboard[Keyboard.ergodox_ez_st]) {
-      chipset = Chipset.stm32;
-    } else {
-      chipset = Chipset.m32u4;
-    }
-    keyboard = Keyboard.ergodox_ez;
-    return { keyboard, chipset };
+    const chipset: Chipset = kbd === Keyboard[Keyboard.ergodox_ez_st] ? Chipset.stm32 : Chipset.m32u4;
+    return { keyboard: kbd, chipset: chipset };
   }
 
   static _queryDomForModel(): Model {

--- a/pages/content-ui/src/App.tsx
+++ b/pages/content-ui/src/App.tsx
@@ -208,7 +208,7 @@ export default function App() {
               href="https://github.com/nivekmai/oryx-build-extension/issues"
               target="_blank"
               rel="noreferrer"
-              className="hover:bg-sky-200 hover:dark:text-black underline">
+              className="underline hover:bg-sky-200 hover:dark:text-black">
               here
             </a>
             .


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->

- `pnpm lint --fix` passes now

## Changes*
- variable reuse and constancy
- null coalescence where applicable

## How to check the feature
<!-- Describe how to check the feature in detail -->
git diff after linting:
```sh
pnpm lint --fix &> /dev/null && git diff --quiet && echo 🟢  || echo 🔴 
git switch --detach @~
pnpm lint --fix &> /dev/null && git diff --quiet && echo 🔴 NO REPRO || echo 🟢 Failing as expected
git switch --discard-changes -
```

end to end tests
```sh
pnpm e2e && echo 🟢 CHROME e2e || echo 🔴 CHROME e2e
pnpm e2e:firefox  && echo 🟢 FIREFOX e2e || echo 🔴 FIREFOX e2e
```

locally, FIREFOX e2e fails consistently, and CHROME e2e passes flakily. I _think_ it has something to do with how long the layout 


run locally:
```sh
pnpm dev
```